### PR TITLE
optimized memory usage in the scan

### DIFF
--- a/utils/build_prj.tcl
+++ b/utils/build_prj.tcl
@@ -8,7 +8,6 @@ set_top myproject
 add_files firmware/myproject.cpp -cflags "-I[file normalize ../../nnet_utils]"
 add_files -tb myproject_test.cpp -cflags "-I[file normalize ../../nnet_utils]"
 add_files -tb firmware/weights
-add_files -tb tb_input_data.dat
 open_solution -reset "solution1"
 set_part {xc7vx690tffg1927-2}
 #set_part {xcvu9p-flgb2104-2-i}

--- a/utils/scan.yml
+++ b/utils/scan.yml
@@ -14,8 +14,8 @@ ReuseFactor:
     - 6
 
 DefaultPrecision:
-    4a4: ap_fixed< 4,4> 
-    8a4: ap_fixed< 8,4> 
+    4a4: ap_fixed<4,4> 
+    8a4: ap_fixed<8,4> 
     12a4: ap_fixed<12,4> 
     16a4: ap_fixed<16,4> 
     20a4: ap_fixed<20,4> 

--- a/utils/scan_parameters.py
+++ b/utils/scan_parameters.py
@@ -190,9 +190,9 @@ def RunProjs(projs,hlsdir,kerasdir):
     for k, v in projs.items():
         PrepareYaml(k, v)
         pwd = os.getcwd()
-        output_filename = '%s/keras-to-hls/results_%s/tb_output_data.dat'%(hlsdir,k) 
-        report_filename = '%s/keras-to-hls/results_%s/myproject_csynth.xml'%(hlsdir,k)
-
+        report_filename = "%s/keras-to-hls/%s/myproject_prj/solution1/syn/report/myproject_csynth.xml" % (hlsdir, k)
+        output_filename = "%s/keras-to-hls/%s/myproject_prj/solution1/csim/build/tb_output_data.dat" % (hlsdir,k)
+        
         if ToRun and not os.path.exists(report_filename):
             ymltorun = "%s/%s.yml" % (pwd, k)
             outlog = open("%s.stdout" % k, 'w')
@@ -217,11 +217,14 @@ def RunProjs(projs,hlsdir,kerasdir):
          
             if os.path.exists(output_filename):
              subprocess.call('cp %s %s/keras-to-hls/results_%s/.'%(output_filename,hlsdir,k),
-                            stdout = outlog, stderr=errlog, shell=True)       
+                            stdout = outlog, stderr=errlog, shell=True) 
+             output_filename = '%s/keras-to-hls/results_%s/tb_output_data.dat'%(hlsdir,k) 	          
               
             if os.path.exists(report_filename):
              subprocess.call('cp %s %s/keras-to-hls/results_%s/.'%(report_filename,hlsdir,k),
                             stdout = outlog, stderr=errlog, shell=True)  
+             report_filename = '%s/keras-to-hls/results_%s/myproject_csynth.xml'%(hlsdir,k)
+
                  
             subprocess.call('rm -rf %s/keras-to-hls/%s'%(hlsdir,k),
                             stdout = outlog, stderr=errlog, shell=True)  


### PR DESCRIPTION
To optimize the memory usage I suggest the following changes:

- Do not copy the test bench data in the project directory as it gets duplicated in several places and use lot of memory. I instead modify the test bench file in the scan such that to point to the existing tb data file. I assume the tb data file is located in the tb_data folder of the repo.

- Do not keep the whole project directory while instead at the end of each project I copy the useful files (synthesis overview and test bench output data) in a new directory. After these files are copied I remove the project directory.

Few additional changes include:

- Save in the output file the AUC and expected AUC for each class. The number of classes for the model is automatically taken from the file with the keras predictions.

- Added a check of the pass/fail status of csim and cosim. If the cosim is not run the check returns anyways true. If the csim fails it returns false and the AUC and/or resources are not written to the output file.